### PR TITLE
Django15 changes content type checking

### DIFF
--- a/rpc4django/views.py
+++ b/rpc4django/views.py
@@ -155,7 +155,7 @@ def serve_rpc_request(request):
 
     '''
 
-    if request.method == "POST" and len(request.POST) > 0:
+    if request.method == "POST" and request.META.get('CONTENT_LENGTH', 0) > 0:
         # Handle POST request with RPC payload
 
         if LOG_REQUESTS_RESPONSES:


### PR DESCRIPTION
In Django 1.5, `request.POST` is only set on some content types. See [this](https://docs.djangoproject.com/en/1.5/releases/1.5/#non-form-data-in-http-requests) for details. 
