### PR TITLE
ignore TypeErrors while checking for rpcmethods.

### DIFF
--- a/rpc4django/rpcdispatcher.py
+++ b/rpc4django/rpcdispatcher.py
@@ -348,7 +348,7 @@ class RPCDispatcher(object):
             # check each app for any rpcmethods
             try:
                 app = __import__(appname, globals(), locals(), ['*'])
-            except (ImportError, ValueError):
+            except (TypeError, ImportError, ValueError):
                 # import throws ValueError on empty "name"
                 continue
 


### PR DESCRIPTION
If an app uses `unicode_literals` from `__future__` and has
strings in its `__init__` import fails.

i.e. [django-debug-toolbar](https://github.com/django-debug-toolbar/django-debug-toolbar/blob/master/debug_toolbar/__init__.py)
