### PR TITLE
Fixes to work the Ruby clients + Python 3.x

### DIFF
--- a/rpc4django/views.py
+++ b/rpc4django/views.py
@@ -91,8 +91,7 @@ def check_request_permission(request, request_format='xml'):
 
     user = getattr(request, 'user', None)
     methods = dispatcher.list_methods()
-    request_body = request.body.decode('utf-8')
-    method_name = dispatcher.get_method_name(request_body, request_format)
+    method_name = dispatcher.get_method_name(request.body, request_format)
     response = True
 
     for method in methods:
@@ -186,10 +185,9 @@ def serve_rpc_request(request):
     if request.method == "POST" and int(request.META.get('CONTENT_LENGTH', 0)) > 0:
         # Handle POST request with RPC payload
 
-        request_body = request.body.decode('utf-8')
-
         if LOG_REQUESTS_RESPONSES:
-            logger.debug('Incoming request: %s' % request_body)
+            body_text = request.body.decode('utf-8')
+            logger.debug('Incoming request: %s' % body_text)
 
         if is_xmlrpc_request(request):
             if RESTRICT_XML:
@@ -198,7 +196,7 @@ def serve_rpc_request(request):
             if not check_request_permission(request, 'xml'):
                 return HttpResponseForbidden()
 
-            resp = dispatcher.xmldispatch(request_body, request=request)
+            resp = dispatcher.xmldispatch(request.body, request=request)
             response_type = 'text/xml'
         else:
             if RESTRICT_JSON:
@@ -207,7 +205,7 @@ def serve_rpc_request(request):
             if not check_request_permission(request, 'json'):
                 return HttpResponseForbidden()
 
-            resp = dispatcher.jsondispatch(request_body, request=request)
+            resp = dispatcher.jsondispatch(request.body, request=request)
             response_type = 'application/json'
 
         if LOG_REQUESTS_RESPONSES:

--- a/rpc4django/views.py
+++ b/rpc4django/views.py
@@ -148,7 +148,7 @@ def is_xmlrpc_request(request):
 
     '''
 
-    conttype = request.META.get('CONTENT_TYPE', 'unknown type')
+    conttype = get_content_type(request)
 
     # check content type for obvious clues
     if conttype == 'text/xml' or conttype == 'application/xml':

--- a/rpc4django/views.py
+++ b/rpc4django/views.py
@@ -59,7 +59,10 @@ APPS = getattr(settings, 'INSTALLED_APPS', [])
 def get_request_body(request):
     if hasattr(request, 'raw_post_data'):
         return request.raw_post_data
-    return request.body
+
+    encoding = getattr(request, 'encoding') or 'UTF-8'
+
+    return request.body.decode(encoding)
 
 
 def get_content_type(request):

--- a/rpc4django/views.py
+++ b/rpc4django/views.py
@@ -70,12 +70,17 @@ def get_content_type(request):
 
     Return `None` if unknown.
     """
-    header = request.META.get('CONTENT_TYPE', None)
 
-    if not header:
-        return None
+    if hasattr(request, 'content_type'):
+        conttype = request.content_type
 
-    conttype = header.partition(';')[0]  # remove ";charset="
+    else:
+        header = request.META.get('CONTENT_TYPE', None)
+
+        if not header:
+            return None
+
+        conttype = header.partition(';')[0]  # remove ";charset="
 
     return conttype
 

--- a/rpc4django/views.py
+++ b/rpc4django/views.py
@@ -158,6 +158,9 @@ def is_xmlrpc_request(request):
 
     conttype = get_content_type(request)
 
+    if not conttype:
+        return False
+
     # check content type for obvious clues
     if conttype == 'text/xml' or conttype == 'application/xml':
         return True

--- a/rpc4django/views.py
+++ b/rpc4django/views.py
@@ -62,6 +62,21 @@ def get_request_body(request):
     return request.body
 
 
+def get_content_type(request):
+    """Return the MIME content type giving the request
+
+    Return `None` if unknown.
+    """
+    header = request.META.get('CONTENT_TYPE', None)
+
+    if not header:
+        return None
+
+    conttype = header.partition(';')[0]  # remove ";charset="
+
+    return conttype
+
+
 def check_request_permission(request, request_format='xml'):
     '''
     Checks whether this user has permission to call a particular method

--- a/rpc4django/views.py
+++ b/rpc4django/views.py
@@ -147,10 +147,7 @@ def is_xmlrpc_request(request):
 
     '''
 
-    conttype = get_content_type(request)
-
-    if not conttype:
-        return False
+    conttype = get_content_type(request) or ''
 
     # check content type for obvious clues
     if conttype == 'text/xml' or conttype == 'application/xml':

--- a/setup.py
+++ b/setup.py
@@ -53,8 +53,7 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
 
-    install_requires=['Django >= 1.4', 'defusedxml'],
-    # tests_require=['Django >= 1.3'],
+    install_requires=['Django>=1.8', 'defusedxml'],
     extras_require={
         "reST": ['docutils >= 0.4'],
     },


### PR DESCRIPTION
The following patches are the result of issues found when using rpc4django on Python 3.4 against a Ruby Client.  The basic issues are:

* Ruby's client sends `'Content-Type: application/xml; charset=utf-8'` which isn't parsed properly
* Furthermore, attempting to `json.loads` the `request.body` in Python 3 fails because it expects `str` not `bytes`
* Drop support for Django <1.8 ias it s no longer supported upstream

In fixing the issue with `json.loads` for XML-RPC requests it actually created an issue for `json.loads` for JSON-RPC requests so that needed to be fixed as well.