### PR TITLE
Circular import fixes for Django 1.10

### DIFF
--- a/rpc4django/rpcdispatcher.py
+++ b/rpc4django/rpcdispatcher.py
@@ -259,8 +259,7 @@ class RPCDispatcher(object):
     **Attributes**
 
     ``url``
-      The URL that handles RPC requests (eg. ``/RPC2``)
-      This is needed by ``system.describe``.
+      (this is no longer used)
     ``rpcmethods``
       A list of :class:`RPCMethod<rpc4django.rpcdispatcher.RPCMethod>` instances
       available to be called by the dispatcher
@@ -293,14 +292,16 @@ class RPCDispatcher(object):
         self.register_rpcmethods(apps)
 
     @rpcmethod(name='system.describe', signature=['struct'])
-    def system_describe(self):
+    def system_describe(self, **kwargs):
         '''
         Returns a simple method description of the methods supported
         '''
 
+        request = kwargs.get('request', None)
+
         description = {}
         description['serviceType'] = 'RPC4Django JSONRPC+XMLRPC'
-        description['serviceURL'] = self.url,
+        description['serviceURL'] = request.path
         description['methods'] = [{'name': method.name,
                                    'summary': method.help,
                                    'params': method.get_params(),

--- a/rpc4django/views.py
+++ b/rpc4django/views.py
@@ -14,9 +14,9 @@ The main entry point for RPC4Django. Usually, the user simply puts
 import logging
 import json
 from django.http import HttpResponse, Http404, HttpResponseForbidden
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from django.conf import settings
-from django.core.urlresolvers import reverse, NoReverseMatch, get_mod_func
+from django.core.urlresolvers import get_mod_func
 from django.views.decorators.csrf import csrf_exempt
 
 try:
@@ -243,7 +243,7 @@ def serve_rpc_request(request):
         methods = dispatcher.list_methods()
         template_data = {
             'methods': methods,
-            'url': URL,
+            'url': request.path,
 
             # rpc4django version
             'version': version(),
@@ -251,17 +251,8 @@ def serve_rpc_request(request):
             # restricts the ability to test the rpc server from the docs
             'restrict_rpctest': RESTRICT_RPCTEST,
         }
-        from django.template import RequestContext
-        return render_to_response('rpc4django/rpcmethod_summary.html',
-                                  template_data,
-                                  context_instance=RequestContext(request))
+        return render(request, 'rpc4django/rpcmethod_summary.html', template_data)
 
-
-# reverse the method for use with system.describe and ajax
-try:
-    URL = reverse(serve_rpc_request)
-except NoReverseMatch:
-    URL = ''
 
 try:
     # Python2
@@ -280,5 +271,5 @@ else:
 
 # instantiate the rpcdispatcher -- this examines the INSTALLED_APPS
 # for any @rpcmethod decorators and adds them to the callable methods
-dispatcher = RPCDispatcher(URL, APPS, RESTRICT_INTROSPECTION,
+dispatcher = RPCDispatcher('', APPS, RESTRICT_INTROSPECTION,
                            RESTRICT_OOTB_AUTH, json_encoder)


### PR DESCRIPTION
Fixes a circular import issue that manifested itself after adding support for Django 1.10. In general, passing the URL to RPCDispatcher is completely unnecessary as the called path can be retrieved from individual requests. It definitely seems to me like the classes could use a bit of a refactor.

Fixes #45.