### PR TITLE
Support django 1.10 + better rpc method discovery

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,10 +36,11 @@ Configuration
     ::
     
         # urls.py
+        from rpc4django.views import serve_rpc_request
 
         urlpatterns = patterns('',
             # rpc4django will need to be in your Python path
-            (r'^RPC2$', 'rpc4django.views.serve_rpc_request'),
+            (r'^RPC2$', serve_rpc_request),
         )
 
 2. Second, add RPC4Django to the list of installed applications in your

--- a/example/urls.py
+++ b/example/urls.py
@@ -1,4 +1,5 @@
 from django.conf.urls import patterns
+from rpc4django.views import serve_rpc_request
 
 # Uncomment the next two lines to enable the admin:
 # from django.contrib import admin
@@ -15,5 +16,5 @@ urlpatterns = patterns('',
     # Uncomment the next line to enable the admin:
     # (r'^admin/(.*)', admin.site.root),
     ('^$', 'rpc4django.views.serve_rpc_request'),
-    ('^RPC2$', 'rpc4django.views.serve_rpc_request'),
+    ('^RPC2$', serve_rpc_request),
 )

--- a/rpc4django/__init__.py
+++ b/rpc4django/__init__.py
@@ -1,7 +1,7 @@
 from .rpcdispatcher import RPCDispatcher, rpcmethod   # noqa
 
 _MAJOR = 0
-_MINOR = 3
+_MINOR = 4
 _PATCH = 0
 
 __version__ = str(_MAJOR) + '.' + str(_MINOR) + '.' + str(_PATCH)

--- a/rpc4django/rpcdispatcher.py
+++ b/rpc4django/rpcdispatcher.py
@@ -11,6 +11,7 @@ import types
 from django.contrib.auth import authenticate, login, logout
 from .jsonrpcdispatcher import JSONRPCDispatcher, json
 from .xmlrpcdispatcher import XMLRPCDispatcher
+from numpy import disp
 
 try:
     # Python2.x
@@ -30,61 +31,6 @@ xmlrpc.monkey_patch()
 # this error code is taken from xmlrpc-epi
 # http://xmlrpc-epi.sourceforge.net/specs/rfc.fault_codes.php
 APPLICATION_ERROR = -32500
-
-
-def rpcmethod(**kwargs):
-    '''
-    Accepts keyword based arguments that describe the method's rpc aspects
-
-    **Parameters**
-
-    ``name``
-      the name of the method to make available via RPC.
-      Defaults to the method's actual name
-    ``signature``
-      the signature of the method that will be returned by
-      calls to the XMLRPC introspection method ``system.methodSignature``.
-      It is of the form: [return_value, arg1, arg2, arg3, ...].
-      All of the types should be XMLRPC types
-      (eg. struct, int, array, etc. - see the XMLRPC spec for details).
-    ``permission``
-      the Django permission required to execute this method
-    ``login_required``
-      the method requires a user to be logged in
-
-    **Examples**
-
-    ::
-
-        @rpcmethod()
-        @rpcmethod(name='myns.myFuncName', signature=['int','int'])
-        @rpcmethod(permission='add_group')
-        @rpcmethod(login_required=True)
-
-    '''
-
-    def set_rpcmethod_info(method):
-        method.is_rpcmethod = True
-        method.signature = []
-        method.permission = None
-        method.login_required = False
-        method.external_name = getattr(method, '__name__')
-
-        if 'name' in kwargs:
-            method.external_name = kwargs['name']
-
-        if 'signature' in kwargs:
-            method.signature = kwargs['signature']
-
-        if 'permission' in kwargs:
-            method.permission = kwargs['permission']
-
-        if 'login_required' in kwargs:
-            method.login_required = kwargs['login_required']
-
-        return method
-    return set_rpcmethod_info
-
 
 class RPCMethod(object):
     '''
@@ -289,18 +235,19 @@ class RPCDispatcher(object):
         if not restrict_ootb_auth:
             self.register_method(self.system_login)
             self.register_method(self.system_logout)
+#         self.register_rpcmethods(apps)
 
-        self.register_rpcmethods(apps)
 
-    @rpcmethod(name='system.describe', signature=['struct'])
-    def system_describe(self):
+#     @rpcmethod(name='system.describe', signature=['struct'])
+    def system_describe(self, **kwargs):
         '''
         Returns a simple method description of the methods supported
         '''
-
+        request = kwargs.get('request', None)
         description = {}
         description['serviceType'] = 'RPC4Django JSONRPC+XMLRPC'
-        description['serviceURL'] = self.url,
+#         description['serviceURL'] = self.url,
+        description['serviceURL'] = request.path,
         description['methods'] = [{'name': method.name,
                                    'summary': method.help,
                                    'params': method.get_params(),
@@ -309,7 +256,7 @@ class RPCDispatcher(object):
 
         return description
 
-    @rpcmethod(name='system.listMethods', signature=['array'])
+#     @rpcmethod(name='system.listMethods', signature=['array'])
     def system_listmethods(self):
         '''
         Returns a list of supported methods
@@ -319,7 +266,7 @@ class RPCDispatcher(object):
         methods.sort()
         return methods
 
-    @rpcmethod(name='system.methodHelp', signature=['string', 'string'])
+#     @rpcmethod(name='system.methodHelp', signature=['string', 'string'])
     def system_methodhelp(self, method_name):
         '''
         Returns documentation for a specified method
@@ -335,7 +282,7 @@ class RPCDispatcher(object):
         raise Fault(APPLICATION_ERROR, 'No method found with name: ' +
                     str(method_name))
 
-    @rpcmethod(name='system.methodSignature', signature=['array', 'string'])
+#     @rpcmethod(name='system.methodSignature', signature=['array', 'string'])
     def system_methodsignature(self, method_name):
         '''
         Returns the signature for a specified method
@@ -347,7 +294,7 @@ class RPCDispatcher(object):
         raise Fault(APPLICATION_ERROR, 'No method found with name: ' +
                     str(method_name))
 
-    @rpcmethod(name='system.login', signature=['boolean', 'string', 'string'])
+#     @rpcmethod(name='system.login', signature=['boolean', 'string', 'string'])
     def system_login(self, username, password, **kwargs):
         '''
         Authorizes a user to enable sending protected RPC requests
@@ -363,7 +310,7 @@ class RPCDispatcher(object):
 
         return False
 
-    @rpcmethod(name='system.logout', signature=['boolean'])
+#     @rpcmethod(name='system.logout', signature=['boolean'])
     def system_logout(self, **kwargs):
         '''
         Deauthorizes a user
@@ -377,34 +324,34 @@ class RPCDispatcher(object):
 
         return False
 
-    def register_rpcmethods(self, apps):
-        '''
-        Scans the installed apps for methods with the rpcmethod decorator
-        Adds these methods to the list of methods callable via RPC
-        '''
-
-        for appname in apps:
-            # check each app for any rpcmethods
-            try:
-                app = __import__(appname, globals(), locals(), ['*'])
-            except (TypeError, ImportError, ValueError):
-                # import throws ValueError on empty "name"
-                continue
-
-            for obj in dir(app):
-                method = getattr(app, obj)
-                if isinstance(method, ServerProxy):
-                    continue
-                if callable(method) and \
-                   hasattr(method, 'is_rpcmethod') and \
-                   method.is_rpcmethod is True:
-                    # if this method is callable and it has the rpcmethod
-                    # decorator, add it to the dispatcher
-                    self.register_method(method, method.external_name)
-                elif isinstance(method, types.ModuleType):
-                    # if this is not a method and instead a sub-module,
-                    # scan the module for methods with @rpcmethod
-                    self.register_rpcmethods(["%s.%s" % (appname, obj)])
+#     def register_rpcmethods(self, apps):
+#         '''
+#         Scans the installed apps for methods with the rpcmethod decorator
+#         Adds these methods to the list of methods callable via RPC
+#         '''
+# 
+#         for appname in apps:
+#             # check each app for any rpcmethods
+#             try:
+#                 app = __import__(appname, globals(), locals(), ['*'])
+#             except (TypeError, ImportError, ValueError):
+#                 # import throws ValueError on empty "name"
+#                 continue
+# 
+#             for obj in dir(app):
+#                 method = getattr(app, obj)
+#                 if isinstance(method, ServerProxy):
+#                     continue
+#                 if callable(method) and \
+#                    hasattr(method, 'is_rpcmethod') and \
+#                    method.is_rpcmethod is True:
+#                     # if this method is callable and it has the rpcmethod
+#                     # decorator, add it to the dispatcher
+#                     self.register_method(method, method.external_name)
+#                 elif isinstance(method, types.ModuleType):
+#                     # if this is not a method and instead a sub-module,
+#                     # scan the module for methods with @rpcmethod
+#                     self.register_rpcmethods(["%s.%s" % (appname, obj)])
 
     def jsondispatch(self, raw_post_data, **kwargs):
         '''
@@ -479,3 +426,100 @@ class RPCDispatcher(object):
             self.xmlrpcdispatcher.register_function(method, meth.name)
             self.jsonrpcdispatcher.register_function(method, meth.name)
             self.rpcmethods.append(meth)
+            
+from django.conf import settings          
+try:
+    from importlib import import_module
+except ImportError:
+    from django.utils.importlib import import_module  
+    
+from django.core.urlresolvers import get_mod_func
+            
+            
+RESTRICT_INTROSPECTION = getattr(settings,
+                                 'RPC4DJANGO_RESTRICT_INTROSPECTION', False)
+RESTRICT_OOTB_AUTH = getattr(settings,
+                             'RPC4DJANGO_RESTRICT_OOTB_AUTH', True)
+
+JSON_ENCODER = getattr(settings, 'RPC4DJANGO_JSON_ENCODER',
+                       'django.core.serializers.json.DjangoJSONEncoder')
+            
+# get a list of the installed django applications
+# these will be scanned for @rpcmethod decorators
+APPS = getattr(settings, 'INSTALLED_APPS', [])            
+
+
+try:
+    # Python2
+    basestring
+except NameError:
+    # Python3
+    basestring = str
+
+    
+
+# resolve JSON_ENCODER to class if it's a string
+if isinstance(JSON_ENCODER, basestring):
+    mod_name, cls_name = get_mod_func(JSON_ENCODER)
+    json_encoder = getattr(import_module(mod_name), cls_name)
+else:
+    json_encoder = JSON_ENCODER
+    
+# instantiate the rpcdispatcher -- this examines the INSTALLED_APPS
+# for any @rpcmethod decorators and adds them to the callable methods
+dispatcher = RPCDispatcher('', APPS, RESTRICT_INTROSPECTION,
+                           RESTRICT_OOTB_AUTH, json_encoder)
+
+def rpcmethod(**kwargs):
+    '''
+    Accepts keyword based arguments that describe the method's rpc aspects
+
+    **Parameters**
+
+    ``name``
+      the name of the method to make available via RPC.
+      Defaults to the method's actual name
+    ``signature``
+      the signature of the method that will be returned by
+      calls to the XMLRPC introspection method ``system.methodSignature``.
+      It is of the form: [return_value, arg1, arg2, arg3, ...].
+      All of the types should be XMLRPC types
+      (eg. struct, int, array, etc. - see the XMLRPC spec for details).
+    ``permission``
+      the Django permission required to execute this method
+    ``login_required``
+      the method requires a user to be logged in
+
+    **Examples**
+
+    ::
+
+        @rpcmethod()
+        @rpcmethod(name='myns.myFuncName', signature=['int','int'])
+        @rpcmethod(permission='add_group')
+        @rpcmethod(login_required=True)
+
+    '''
+
+    def set_rpcmethod_info(method):
+        method.is_rpcmethod = True
+        method.signature = []
+        method.permission = None
+        method.login_required = False
+        method.external_name = getattr(method, '__name__')
+
+        if 'name' in kwargs:
+            method.external_name = kwargs['name']
+
+        if 'signature' in kwargs:
+            method.signature = kwargs['signature']
+
+        if 'permission' in kwargs:
+            method.permission = kwargs['permission']
+
+        if 'login_required' in kwargs:
+            method.login_required = kwargs['login_required']
+
+        dispatcher.register_method(method)
+        return method
+    return set_rpcmethod_info

--- a/rpc4django/rpcdispatcher.py
+++ b/rpc4django/rpcdispatcher.py
@@ -231,14 +231,14 @@ class RPCDispatcher(object):
         self.xmlrpcdispatcher = XMLRPCDispatcher()
 
         if not restrict_introspection:
-            self.register_method(self.system_listmethods,'system.listMethods',['array'])
-            self.register_method(self.system_methodhelp,'system.methodHelp',['string', 'string'])
-            self.register_method(self.system_methodsignature,'system.methodSignature',['array', 'string'])
-            self.register_method(self.system_describe,'system.describe',['struct'])
+            self.register_method(self.system_listmethods, 'system.listMethods', ['array'])
+            self.register_method(self.system_methodhelp, 'system.methodHelp', ['string', 'string'])
+            self.register_method(self.system_methodsignature, 'system.methodSignature', ['array', 'string'])
+            self.register_method(self.system_describe, 'system.describe', ['struct'])
 
         if not restrict_ootb_auth:
-            self.register_method(self.system_login,'system.login',['boolean', 'string', 'string'])
-            self.register_method(self.system_logout,'system.logout',['boolean'])
+            self.register_method(self.system_login, 'system.login', ['boolean', 'string', 'string'])
+            self.register_method(self.system_logout, 'system.logout', ['boolean'])
 
 #     @rpcmethod(name='system.describe', signature=['struct'])
     def system_describe(self, **kwargs):

--- a/rpc4django/rpcdispatcher.py
+++ b/rpc4django/rpcdispatcher.py
@@ -19,10 +19,10 @@ from django.core.urlresolvers import get_mod_func
 
 try:
     # Python2.x
-    from xmlrpclib import Fault, ServerProxy
+    from xmlrpclib import Fault
 except ImportError:
     # Python3
-    from xmlrpc.client import Fault, ServerProxy
+    from xmlrpc.client import Fault
 
 from defusedxml import xmlrpc
 

--- a/rpc4django/rpcdispatcher.py
+++ b/rpc4django/rpcdispatcher.py
@@ -10,12 +10,11 @@ import pydoc
 from django.contrib.auth import authenticate, login, logout
 from .jsonrpcdispatcher import JSONRPCDispatcher, json
 from .xmlrpcdispatcher import XMLRPCDispatcher
-from django.conf import settings          
+from django.conf import settings
 try:
     from importlib import import_module
 except ImportError:
-    from django.utils.importlib import import_module  
-    
+    from django.utils.importlib import import_module
 from django.core.urlresolvers import get_mod_func
 
 try:
@@ -399,8 +398,8 @@ class RPCDispatcher(object):
             self.xmlrpcdispatcher.register_function(method, meth.name)
             self.jsonrpcdispatcher.register_function(method, meth.name)
             self.rpcmethods.append(meth)
-            
-            
+
+
 RESTRICT_INTROSPECTION = getattr(settings,
                                  'RPC4DJANGO_RESTRICT_INTROSPECTION', False)
 RESTRICT_OOTB_AUTH = getattr(settings,
@@ -408,7 +407,7 @@ RESTRICT_OOTB_AUTH = getattr(settings,
 
 JSON_ENCODER = getattr(settings, 'RPC4DJANGO_JSON_ENCODER',
                        'django.core.serializers.json.DjangoJSONEncoder')
-            
+
 try:
     # Python2
     basestring
@@ -422,11 +421,12 @@ if isinstance(JSON_ENCODER, basestring):
     json_encoder = getattr(import_module(mod_name), cls_name)
 else:
     json_encoder = JSON_ENCODER
-    
+
 # instantiate the rpcdispatcher -- this examines the INSTALLED_APPS
 # for any @rpcmethod decorators and adds them to the callable methods
 dispatcher = RPCDispatcher(RESTRICT_INTROSPECTION,
                            RESTRICT_OOTB_AUTH, json_encoder)
+
 
 def rpcmethod(**kwargs):
     '''

--- a/rpc4django/rpcdispatcher.py
+++ b/rpc4django/rpcdispatcher.py
@@ -7,11 +7,16 @@ It also contains a decorator to mark methods as rpc methods.
 
 import inspect
 import pydoc
-import types
 from django.contrib.auth import authenticate, login, logout
 from .jsonrpcdispatcher import JSONRPCDispatcher, json
 from .xmlrpcdispatcher import XMLRPCDispatcher
-from numpy import disp
+from django.conf import settings          
+try:
+    from importlib import import_module
+except ImportError:
+    from django.utils.importlib import import_module  
+    
+from django.core.urlresolvers import get_mod_func
 
 try:
     # Python2.x
@@ -31,6 +36,7 @@ xmlrpc.monkey_patch()
 # this error code is taken from xmlrpc-epi
 # http://xmlrpc-epi.sourceforge.net/specs/rfc.fault_codes.php
 APPLICATION_ERROR = -32500
+
 
 class RPCMethod(object):
     '''
@@ -219,9 +225,8 @@ class RPCDispatcher(object):
 
     '''
 
-    def __init__(self, url='', apps=[], restrict_introspection=False,
+    def __init__(self, restrict_introspection=False,
                  restrict_ootb_auth=True, json_encoder=None):
-        self.url = url
         self.rpcmethods = []        # a list of RPCMethod objects
         self.jsonrpcdispatcher = JSONRPCDispatcher(json_encoder)
         self.xmlrpcdispatcher = XMLRPCDispatcher()
@@ -235,8 +240,6 @@ class RPCDispatcher(object):
         if not restrict_ootb_auth:
             self.register_method(self.system_login)
             self.register_method(self.system_logout)
-#         self.register_rpcmethods(apps)
-
 
 #     @rpcmethod(name='system.describe', signature=['struct'])
     def system_describe(self, **kwargs):
@@ -246,7 +249,6 @@ class RPCDispatcher(object):
         request = kwargs.get('request', None)
         description = {}
         description['serviceType'] = 'RPC4Django JSONRPC+XMLRPC'
-#         description['serviceURL'] = self.url,
         description['serviceURL'] = request.path,
         description['methods'] = [{'name': method.name,
                                    'summary': method.help,
@@ -324,35 +326,6 @@ class RPCDispatcher(object):
 
         return False
 
-#     def register_rpcmethods(self, apps):
-#         '''
-#         Scans the installed apps for methods with the rpcmethod decorator
-#         Adds these methods to the list of methods callable via RPC
-#         '''
-# 
-#         for appname in apps:
-#             # check each app for any rpcmethods
-#             try:
-#                 app = __import__(appname, globals(), locals(), ['*'])
-#             except (TypeError, ImportError, ValueError):
-#                 # import throws ValueError on empty "name"
-#                 continue
-# 
-#             for obj in dir(app):
-#                 method = getattr(app, obj)
-#                 if isinstance(method, ServerProxy):
-#                     continue
-#                 if callable(method) and \
-#                    hasattr(method, 'is_rpcmethod') and \
-#                    method.is_rpcmethod is True:
-#                     # if this method is callable and it has the rpcmethod
-#                     # decorator, add it to the dispatcher
-#                     self.register_method(method, method.external_name)
-#                 elif isinstance(method, types.ModuleType):
-#                     # if this is not a method and instead a sub-module,
-#                     # scan the module for methods with @rpcmethod
-#                     self.register_rpcmethods(["%s.%s" % (appname, obj)])
-
     def jsondispatch(self, raw_post_data, **kwargs):
         '''
         Sends the post data to :meth:`rpc4django.jsonrpcdispatcher.JSONRPCDispatcher.dispatch`
@@ -427,14 +400,6 @@ class RPCDispatcher(object):
             self.jsonrpcdispatcher.register_function(method, meth.name)
             self.rpcmethods.append(meth)
             
-from django.conf import settings          
-try:
-    from importlib import import_module
-except ImportError:
-    from django.utils.importlib import import_module  
-    
-from django.core.urlresolvers import get_mod_func
-            
             
 RESTRICT_INTROSPECTION = getattr(settings,
                                  'RPC4DJANGO_RESTRICT_INTROSPECTION', False)
@@ -444,19 +409,12 @@ RESTRICT_OOTB_AUTH = getattr(settings,
 JSON_ENCODER = getattr(settings, 'RPC4DJANGO_JSON_ENCODER',
                        'django.core.serializers.json.DjangoJSONEncoder')
             
-# get a list of the installed django applications
-# these will be scanned for @rpcmethod decorators
-APPS = getattr(settings, 'INSTALLED_APPS', [])            
-
-
 try:
     # Python2
     basestring
 except NameError:
     # Python3
     basestring = str
-
-    
 
 # resolve JSON_ENCODER to class if it's a string
 if isinstance(JSON_ENCODER, basestring):
@@ -467,7 +425,7 @@ else:
     
 # instantiate the rpcdispatcher -- this examines the INSTALLED_APPS
 # for any @rpcmethod decorators and adds them to the callable methods
-dispatcher = RPCDispatcher('', APPS, RESTRICT_INTROSPECTION,
+dispatcher = RPCDispatcher(RESTRICT_INTROSPECTION,
                            RESTRICT_OOTB_AUTH, json_encoder)
 
 def rpcmethod(**kwargs):

--- a/rpc4django/rpcdispatcher.py
+++ b/rpc4django/rpcdispatcher.py
@@ -231,14 +231,14 @@ class RPCDispatcher(object):
         self.xmlrpcdispatcher = XMLRPCDispatcher()
 
         if not restrict_introspection:
-            self.register_method(self.system_listmethods)
-            self.register_method(self.system_methodhelp)
-            self.register_method(self.system_methodsignature)
-            self.register_method(self.system_describe)
+            self.register_method(self.system_listmethods,'system.listMethods',['array'])
+            self.register_method(self.system_methodhelp,'system.methodHelp',['string', 'string'])
+            self.register_method(self.system_methodsignature,'system.methodSignature',['array', 'string'])
+            self.register_method(self.system_describe,'system.describe',['struct'])
 
         if not restrict_ootb_auth:
-            self.register_method(self.system_login)
-            self.register_method(self.system_logout)
+            self.register_method(self.system_login,'system.login',['boolean', 'string', 'string'])
+            self.register_method(self.system_logout,'system.logout',['boolean'])
 
 #     @rpcmethod(name='system.describe', signature=['struct'])
     def system_describe(self, **kwargs):

--- a/rpc4django/views.py
+++ b/rpc4django/views.py
@@ -19,9 +19,7 @@ from django.conf import settings
 
 from django.views.decorators.csrf import csrf_exempt
 
-
-
-from .rpcdispatcher import RPCDispatcher,dispatcher
+from .rpcdispatcher import dispatcher
 from .__init__ import version
 
 logger = logging.getLogger('rpc4django')
@@ -42,9 +40,6 @@ HTTP_ACCESS_CREDENTIALS = getattr(settings,
                                   'RPC4DJANGO_HTTP_ACCESS_CREDENTIALS', False)
 HTTP_ACCESS_ALLOW_ORIGIN = getattr(settings,
                                    'RPC4DJANGO_HTTP_ACCESS_ALLOW_ORIGIN', '')
-
-
-
 
 
 def get_content_type(request):
@@ -234,7 +229,6 @@ def serve_rpc_request(request):
         methods = dispatcher.list_methods()
         template_data = {
             'methods': methods,
-#             'url': URL,
             'url': request.path,
 
             # rpc4django version
@@ -247,16 +241,3 @@ def serve_rpc_request(request):
         return render_to_response('rpc4django/rpcmethod_summary.html',
                                   template_data,
                                   context_instance=RequestContext(request))
-
-
-# reverse the method for use with system.describe and ajax
-# try:
-#     URL = reverse(serve_rpc_request)
-# except NoReverseMatch:
-#     URL = ''
-
-
-    
-
-
-

--- a/rpc4django/views.py
+++ b/rpc4django/views.py
@@ -16,15 +16,12 @@ import json
 from django.http import HttpResponse, Http404, HttpResponseForbidden
 from django.shortcuts import render_to_response
 from django.conf import settings
-from django.core.urlresolvers import reverse, NoReverseMatch, get_mod_func
+
 from django.views.decorators.csrf import csrf_exempt
 
-try:
-    from importlib import import_module
-except ImportError:
-    from django.utils.importlib import import_module
 
-from .rpcdispatcher import RPCDispatcher
+
+from .rpcdispatcher import RPCDispatcher,dispatcher
 from .__init__ import version
 
 logger = logging.getLogger('rpc4django')
@@ -34,10 +31,7 @@ logger = logging.getLogger('rpc4django')
 # see the rpc4django documentation for more details
 LOG_REQUESTS_RESPONSES = getattr(settings,
                                  'RPC4DJANGO_LOG_REQUESTS_RESPONSES', True)
-RESTRICT_INTROSPECTION = getattr(settings,
-                                 'RPC4DJANGO_RESTRICT_INTROSPECTION', False)
-RESTRICT_OOTB_AUTH = getattr(settings,
-                             'RPC4DJANGO_RESTRICT_OOTB_AUTH', True)
+
 RESTRICT_JSON = getattr(settings, 'RPC4DJANGO_RESTRICT_JSONRPC', False)
 RESTRICT_XML = getattr(settings, 'RPC4DJANGO_RESTRICT_XMLRPC', False)
 RESTRICT_METHOD_SUMMARY = getattr(settings,
@@ -48,12 +42,9 @@ HTTP_ACCESS_CREDENTIALS = getattr(settings,
                                   'RPC4DJANGO_HTTP_ACCESS_CREDENTIALS', False)
 HTTP_ACCESS_ALLOW_ORIGIN = getattr(settings,
                                    'RPC4DJANGO_HTTP_ACCESS_ALLOW_ORIGIN', '')
-JSON_ENCODER = getattr(settings, 'RPC4DJANGO_JSON_ENCODER',
-                       'django.core.serializers.json.DjangoJSONEncoder')
 
-# get a list of the installed django applications
-# these will be scanned for @rpcmethod decorators
-APPS = getattr(settings, 'INSTALLED_APPS', [])
+
+
 
 
 def get_content_type(request):
@@ -243,7 +234,8 @@ def serve_rpc_request(request):
         methods = dispatcher.list_methods()
         template_data = {
             'methods': methods,
-            'url': URL,
+#             'url': URL,
+            'url': request.path,
 
             # rpc4django version
             'version': version(),
@@ -258,27 +250,13 @@ def serve_rpc_request(request):
 
 
 # reverse the method for use with system.describe and ajax
-try:
-    URL = reverse(serve_rpc_request)
-except NoReverseMatch:
-    URL = ''
-
-try:
-    # Python2
-    basestring
-except NameError:
-    # Python3
-    basestring = str
-
-# resolve JSON_ENCODER to class if it's a string
-if isinstance(JSON_ENCODER, basestring):
-    mod_name, cls_name = get_mod_func(JSON_ENCODER)
-    json_encoder = getattr(import_module(mod_name), cls_name)
-else:
-    json_encoder = JSON_ENCODER
+# try:
+#     URL = reverse(serve_rpc_request)
+# except NoReverseMatch:
+#     URL = ''
 
 
-# instantiate the rpcdispatcher -- this examines the INSTALLED_APPS
-# for any @rpcmethod decorators and adds them to the callable methods
-dispatcher = RPCDispatcher(URL, APPS, RESTRICT_INTROSPECTION,
-                           RESTRICT_OOTB_AUTH, json_encoder)
+    
+
+
+


### PR DESCRIPTION
Move dispatcher creation from views.py to rpcdispatcher.py
"better" rpc method registration using decorator (avoiding scanning all app)
Support for django 1.10 urls pattern avoiding circular import