### PR TITLE
clean way to provide request argument

### DIFF
--- a/docs/overview.txt
+++ b/docs/overview.txt
@@ -43,7 +43,7 @@ Contributors
 - Albert Hopkins
 - d9pouces
 - hansenerd
-- doudz
+- Sébastien RAMAGE
 
 .. _David Fischer: mailto:rpc4django@davidfischer.name
 .. _wish list: http://amzn.com/w/1Z1GLQYQPFBT1

--- a/docs/usage/request.txt
+++ b/docs/usage/request.txt
@@ -4,12 +4,25 @@ Access to HttpRequest
 RPC4Django allows RPC methods to be written in such a way that they have
 access to Django's HttpRequest_ object. This can be used
 to see the type of request, the user making the request or any specific
-headers in the request object. To use this, methods must be written such 
-that they can accept arbitrary
-keyword arguments. Although currently only the HttpRequest object is sent,
+headers in the request object. To use this, methods could be written such 
+that they can accept arbitrary keyword arguments or 
+specifing request has first argument like classic django view function.
+Although currently only the HttpRequest object is sent,
 additional keyword arguments may be sent in the future.
 
 .. _HttpRequest: http://docs.djangoproject.com/en/dev/ref/request-response/
+
+::
+
+ @rpcmethod(name='rpc4django.httprequest',signature=['string'])
+ def request(request):
+     '''
+     Illustrates access to the HttpRequest object
+     '''
+     
+     return str(request)
+
+or 
 
 ::
 

--- a/docs/usage/request.txt
+++ b/docs/usage/request.txt
@@ -4,33 +4,17 @@ Access to HttpRequest
 RPC4Django allows RPC methods to be written in such a way that they have
 access to Django's HttpRequest_ object. This can be used
 to see the type of request, the user making the request or any specific
-headers in the request object. To use this, methods could be written such 
-that they can accept arbitrary keyword arguments or 
-specifing request has first argument like classic django view function.
-Although currently only the HttpRequest object is sent,
-additional keyword arguments may be sent in the future.
+headers in the request object. To use this, the first argument have to be
+named "request" like classic django view function.
 
 .. _HttpRequest: http://docs.djangoproject.com/en/dev/ref/request-response/
 
 ::
 
  @rpcmethod(name='rpc4django.httprequest',signature=['string'])
- def request(request):
+ def httprequest(request):
      '''
      Illustrates access to the HttpRequest object
      '''
      
-     return str(request)
-
-or 
-
-::
-
- @rpcmethod(name='rpc4django.httprequest',signature=['string'])
- def request(**kwargs):
-     '''
-     Illustrates access to the HttpRequest object
-     '''
-     
-     return str(kwargs.get('request', None))
-     
+     return str(request)    

--- a/example/testapp/__init__.py
+++ b/example/testapp/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from rpc4django import rpcmethod
-from .othermodule import intro, request
+from .othermodule import intro, getrequest
 from .secretmodule import * # imports protected method
 
 @rpcmethod(name='rpc4django.mytestmethod',signature=['int', 'int', 'int', 'int'])

--- a/example/testapp/othermodule.py
+++ b/example/testapp/othermodule.py
@@ -39,13 +39,24 @@ def intro():
     
     return u'はじめまして'
 
-@rpcmethod(name='view.request')
-def request(**kwargs):
+@rpcmethod(name='view.getrequest')
+def getrequest(**kwargs):
     '''
     Illustrates access to the HttpRequest object
     '''
     
     request = kwargs.get('request', None)
+    
+    if request is not None:
+        return str(request)
+    else:
+        return "No Access"
+    
+@rpcmethod(name='view.getrequest2')
+def getrequest2(request):
+    '''
+    Other example to illustrates access to the HttpRequest object
+    '''
     
     if request is not None:
         return str(request)

--- a/rpc4django/__init__.py
+++ b/rpc4django/__init__.py
@@ -1,7 +1,7 @@
 from .rpcdispatcher import RPCDispatcher, rpcmethod   # noqa
 
 _MAJOR = 0
-_MINOR = 4
+_MINOR = 5
 _PATCH = 0
 
 __version__ = str(_MAJOR) + '.' + str(_MINOR) + '.' + str(_PATCH)

--- a/rpc4django/jsonrpcdispatcher.py
+++ b/rpc4django/jsonrpcdispatcher.py
@@ -127,7 +127,7 @@ class JSONRPCDispatcher(object):
             # if request is the first arg of func and request is provided in kwargs we inject it
             if 'request' in kwargs and inspect.getargspec(func)[0][0] == 'request':
                 request = kwargs.pop('request')
-                params = (request,) + params
+                params = [request,] + params
             try:
                 try:
                     result = func(*params, **kwargs)

--- a/rpc4django/jsonrpcdispatcher.py
+++ b/rpc4django/jsonrpcdispatcher.py
@@ -131,7 +131,7 @@ class JSONRPCDispatcher(object):
                 args = inspect.getargspec(func)[0]
             if args and 'request' in kwargs and args[0] == 'request':
                 request = kwargs.pop('request')
-                params = [request,] + params
+                params = [request, ] + params
             try:
                 try:
                     result = func(*params, **kwargs)

--- a/rpc4django/jsonrpcdispatcher.py
+++ b/rpc4django/jsonrpcdispatcher.py
@@ -4,6 +4,7 @@ This module implements a JSON 1.0 compatible dispatcher
 see http://json-rpc.org/wiki/specification
 '''
 
+import inspect
 import json
 
 # indent the json output by this many characters
@@ -120,12 +121,19 @@ class JSONRPCDispatcher(object):
                 'code': JSONRPC_BAD_CALL_ERROR})
 
         if jsondict['method'] in self.methods:
+            func = self.methods[jsondict.get('method')]
+            params = jsondict.get('params', [])
+            #add some magic
+            #if request is the first arg of func and request is provided in kwargs we inject it
+            if 'request' in kwargs and inspect.getargspec(func)[0][0] == 'request':
+                request = kwargs.pop('request')
+                params = (request,)+params
             try:
                 try:
-                    result = self.methods[jsondict.get('method')](*jsondict.get('params', []), **kwargs)
+                    result = func(*params, **kwargs)
                 except TypeError:
                     # Catch unexpected keyword argument error
-                    result = self.methods[jsondict.get('method')](*jsondict.get('params', []))
+                    result = func(*params)
             except JSONRPCException as e:
                 # Custom message and code
                 return self._encode_result(jsondict.get('id', ''), None, {

--- a/rpc4django/jsonrpcdispatcher.py
+++ b/rpc4django/jsonrpcdispatcher.py
@@ -123,8 +123,8 @@ class JSONRPCDispatcher(object):
         if jsondict['method'] in self.methods:
             func = self.methods[jsondict.get('method')]
             params = jsondict.get('params', [])
-            #add some magic
-            #if request is the first arg of func and request is provided in kwargs we inject it
+            # add some magic
+            # if request is the first arg of func and request is provided in kwargs we inject it
             if 'request' in kwargs and inspect.getargspec(func)[0][0] == 'request':
                 request = kwargs.pop('request')
                 params = (request,)+params

--- a/rpc4django/jsonrpcdispatcher.py
+++ b/rpc4django/jsonrpcdispatcher.py
@@ -125,9 +125,13 @@ class JSONRPCDispatcher(object):
             params = jsondict.get('params', [])
             # add some magic
             # if request is the first arg of func and request is provided in kwargs we inject it
-            if 'request' in kwargs and inspect.getargspec(func)[0][0] == 'request':
+            if hasattr(inspect, 'signature'):  # python 3
+                args = list(inspect.signature(func).parameters)
+            else:  # python 2
+                args = inspect.getargspec(func)[0]
+            if args and 'request' in kwargs and args[0] == 'request':
                 request = kwargs.pop('request')
-                params = [request] + params
+                params = [request,] + params
             try:
                 try:
                     result = func(*params, **kwargs)

--- a/rpc4django/jsonrpcdispatcher.py
+++ b/rpc4django/jsonrpcdispatcher.py
@@ -127,7 +127,7 @@ class JSONRPCDispatcher(object):
             # if request is the first arg of func and request is provided in kwargs we inject it
             if 'request' in kwargs and inspect.getargspec(func)[0][0] == 'request':
                 request = kwargs.pop('request')
-                params = (request,)+params
+                params = (request,) + params
             try:
                 try:
                     result = func(*params, **kwargs)

--- a/rpc4django/jsonrpcdispatcher.py
+++ b/rpc4django/jsonrpcdispatcher.py
@@ -127,7 +127,7 @@ class JSONRPCDispatcher(object):
             # if request is the first arg of func and request is provided in kwargs we inject it
             if 'request' in kwargs and inspect.getargspec(func)[0][0] == 'request':
                 request = kwargs.pop('request')
-                params = [request,] + params
+                params = [request] + params
             try:
                 try:
                     result = func(*params, **kwargs)

--- a/rpc4django/rpcdispatcher.py
+++ b/rpc4django/rpcdispatcher.py
@@ -125,7 +125,7 @@ class RPCMethod(object):
         for i, arg in enumerate(self.args):
             annotation = annotations.get(arg, None)
             if annotation:
-                self.signature.append(annotation.__name__)
+                self.signature.append(annotation)
             else:
                 try:
                     self.signature.append(method.signature[i])

--- a/rpc4django/rpcdispatcher.py
+++ b/rpc4django/rpcdispatcher.py
@@ -121,7 +121,7 @@ class RPCMethod(object):
                      for arg in args
                      if arg not in ('self', 'request')]
 
-        self.signature.append(annotations.get('return', object).__name__)
+        self.signature.append(annotations.get('return', 'object'))
         for i, arg in enumerate(self.args):
             annotation = annotations.get(arg, None)
             if annotation:

--- a/rpc4django/rpcdispatcher.py
+++ b/rpc4django/rpcdispatcher.py
@@ -119,7 +119,7 @@ class RPCMethod(object):
 
         self.args = [arg
                      for arg in args
-                     if arg != 'self']
+                     if arg not in ('self', 'request')]
 
         self.signature.append(annotations.get('return', object).__name__)
         for i, arg in enumerate(self.args):

--- a/rpc4django/rpcdispatcher.py
+++ b/rpc4django/rpcdispatcher.py
@@ -183,12 +183,16 @@ class RPCMethod(object):
             arglist = []
             if len(self.signature) == len(self.args) + 1:
                 for argnum in range(len(self.args)):
+                    if self.args[argnum] == 'request':
+                        continue
                     arglist.append({'name': self.args[argnum],
                                     'rpctype': self.signature[argnum + 1]})
                 return arglist
             else:
                 # this should not happen under normal usage
                 for argnum in range(len(self.args)):
+                    if self.args[argnum] == 'request':
+                        continue
                     arglist.append({'name': self.args[argnum],
                                     'rpctype': 'object'})
                 return arglist

--- a/rpc4django/xmlrpcdispatcher.py
+++ b/rpc4django/xmlrpcdispatcher.py
@@ -78,7 +78,11 @@ class XMLRPCDispatcher(SimpleXMLRPCDispatcher):
         func = self.funcs.get(method, None)
         # add some magic
         # if request is the first arg of func and request is provided in kwargs we inject it
-        if 'request' in kwargs and inspect.getargspec(func)[0][0] == 'request':
+        if hasattr(inspect, 'signature'): # python 3
+            args = list(inspect.signature(func).parameters)
+        else: # python 2
+            args = inspect.getargspec(func)[0]
+        if args and 'request' in kwargs and args[0] == 'request':
             request = kwargs.pop('request')
             params = (request,) + params
         if func is not None:

--- a/rpc4django/xmlrpcdispatcher.py
+++ b/rpc4django/xmlrpcdispatcher.py
@@ -11,6 +11,7 @@ except ImportError:
     from xmlrpc.client import Fault, dumps
     from xmlrpc.server import SimpleXMLRPCDispatcher
 
+import inspect
 from defusedxml import xmlrpc
 
 # This method makes the XMLRPC parser (used by loads) safe
@@ -75,7 +76,13 @@ class XMLRPCDispatcher(SimpleXMLRPCDispatcher):
         """
 
         func = self.funcs.get(method, None)
-
+        
+        #add some magic
+        #if request is the first arg of func and request is provided in kwargs we inject it
+        if 'request' in kwargs and inspect.getargspec(func)[0][0] == 'request':
+            request = kwargs.pop('request')
+            params = (request,) + params
+        
         if func is not None:
             if len(kwargs) > 0:
                 return func(*params, **kwargs)

--- a/rpc4django/xmlrpcdispatcher.py
+++ b/rpc4django/xmlrpcdispatcher.py
@@ -76,13 +76,11 @@ class XMLRPCDispatcher(SimpleXMLRPCDispatcher):
         """
 
         func = self.funcs.get(method, None)
-        
-        #add some magic
-        #if request is the first arg of func and request is provided in kwargs we inject it
+        # add some magic
+        # if request is the first arg of func and request is provided in kwargs we inject it
         if 'request' in kwargs and inspect.getargspec(func)[0][0] == 'request':
             request = kwargs.pop('request')
             params = (request,) + params
-        
         if func is not None:
             if len(kwargs) > 0:
                 return func(*params, **kwargs)

--- a/rpc4django/xmlrpcdispatcher.py
+++ b/rpc4django/xmlrpcdispatcher.py
@@ -78,9 +78,9 @@ class XMLRPCDispatcher(SimpleXMLRPCDispatcher):
         func = self.funcs.get(method, None)
         # add some magic
         # if request is the first arg of func and request is provided in kwargs we inject it
-        if hasattr(inspect, 'signature'): # python 3
+        if hasattr(inspect, 'signature'):  # python 3
             args = list(inspect.signature(func).parameters)
-        else: # python 2
+        else:  # python 2
             args = inspect.getargspec(func)[0]
         if args and 'request' in kwargs and args[0] == 'request':
             request = kwargs.pop('request')

--- a/tests/test_jsonrpcdispatcher.py
+++ b/tests/test_jsonrpcdispatcher.py
@@ -47,6 +47,12 @@ class TestJSONRPCDispatcher(unittest.TestCase):
             if kwargs.get('c', None) is not None:
                 return True
             return False
+        
+        def withoutargstest():
+            return True
+        
+        def requestargtest(request,a):
+            return request
 
         self.dispatcher = JSONRPCDispatcher()
         self.dispatcher.register_function(add, 'add')
@@ -54,6 +60,8 @@ class TestJSONRPCDispatcher(unittest.TestCase):
         self.dispatcher.register_function(unicode_ret, 'unicode_ret')
         self.dispatcher.register_function(kwargstest, 'kwargstest')
         self.dispatcher.register_function(lambda: datetime.now(), 'datetest')
+        self.dispatcher.register_function(requestargtest, 'requestargtest')
+        self.dispatcher.register_function(withoutargstest, 'withoutargstest')
 
     def test_dates(self):
         jsontxt = json.dumps({"method": "datetest", "id": 1, "params": []})
@@ -99,6 +107,16 @@ class TestJSONRPCDispatcher(unittest.TestCase):
         self.assertFalse(jsondict['result'])
 
         resp = self.dispatcher.dispatch(jsontxt, c=1)
+        jsondict = json.loads(resp)
+        self.assertTrue(jsondict['result'])
+        
+        jsontxt = json.dumps({'params':(1,), 'method':'requestargtest'})
+        resp = self.dispatcher.dispatch(jsontxt, request=True)
+        jsondict = json.loads(resp)
+        self.assertTrue(jsondict['result'])
+        
+        jsontxt = json.dumps({'params':[], 'method':'withoutargstest'})
+        resp = self.dispatcher.dispatch(jsontxt, request='fakerequest')
         jsondict = json.loads(resp)
         self.assertTrue(jsondict['result'])
 

--- a/tests/test_xmlrpcdispatcher.py
+++ b/tests/test_xmlrpcdispatcher.py
@@ -29,9 +29,17 @@ class TestXMLRPCDispatcher(unittest.TestCase):
             if kwargs.get('c', None) is not None:
                 return True
             return False
+        
+        def withoutargstest():
+            return True
+        
+        def requestargtest(request,a):
+            return request
 
         self.dispatcher = XMLRPCDispatcher()
         self.dispatcher.register_function(kwargstest, 'kwargstest')
+        self.dispatcher.register_function(requestargtest, 'requestargtest')
+        self.dispatcher.register_function(withoutargstest, 'withoutargstest')
 
     def test_kwargs(self):
         xml = dumps((1, 2), 'kwargstest')
@@ -40,6 +48,22 @@ class TestXMLRPCDispatcher(unittest.TestCase):
         self.assertFalse(out[0])
 
         ret = self.dispatcher.dispatch(xml, c=1)
+        out, name = loads(ret)
+        self.assertTrue(out[0])
+        
+        xml = dumps((1,),'requestargtest')
+        ret = self.dispatcher.dispatch(xml, request=True)
+        out, name = loads(ret)
+        self.assertTrue(out[0])
+        
+        xml = """<?xml version='1.0'?>
+<methodCall>
+<methodName>withoutargstest</methodName>
+<params>
+</params>
+</methodCall>
+        """
+        ret = self.dispatcher.dispatch(xml, request='fakerequest')
         out, name = loads(ret)
         self.assertTrue(out[0])
 


### PR DESCRIPTION
No need to use kwargs anymore to access the HttpRequest
if "request" is the first argument of the function (like a normal django view function) the "request" is automatically provided
instead of :
```
@rpcmethod(name='rpc4django.httprequest',signature=['string'])
def httprequest(**kwargs):
    return str(kwargs['request'])
```

you can now use
```
@rpcmethod(name='rpc4django.httprequest',signature=['string'])
def httprequest(request):
    return str(request)
```