### PR TITLE
Django 2.0 compatibility fix

### DIFF
--- a/rpc4django/rpcdispatcher.py
+++ b/rpc4django/rpcdispatcher.py
@@ -15,7 +15,11 @@ try:
     from importlib import import_module
 except ImportError:
     from django.utils.importlib import import_module
-from django.core.urlresolvers import get_mod_func
+try:
+    from django.core.urlresolvers import get_mod_func
+except ModuleNotFoundError:
+    #Django 2.0+
+    from django.urls import get_mod_func
 
 try:
     # Python2.x


### PR DESCRIPTION
Building with rpc4django in the stack on Django 2.0 fails due to django.core.urlresolvers becoming django.urls.

I can't promise that this is the only update needed to work with Django 2+, but with this fix I can run basic manage.py commands again.